### PR TITLE
Only verify connection is verify_role option is set

### DIFF
--- a/lib/redix_sentinel.ex
+++ b/lib/redix_sentinel.ex
@@ -246,8 +246,12 @@ defmodule RedixSentinel do
       _ = log(s, :sentinel_connection, "Got #{role} address #{inspect(node_info)}")
       {:ok, conn} = Redix.start_link(Keyword.merge(s.redis_connection_opts, node_info), Keyword.merge(s.redix_behaviour_opts, [exit_on_disconnection: true]))
 
-      _ = log(s, :sentinel_connection, "Verifying role")
-      [^role | _] = Redix.command!(conn, ["ROLE"])
+
+      verify_role = Keyword.fetch!(sentinel_opts, :verify_role)
+      if verify_role > 0 do
+        _ = log(s, :sentinel_connection, "Verifying role")
+        [^role | _] = Redix.command!(conn, ["ROLE"])
+      end
 
       Redix.stop(sentinel_conn)
 

--- a/lib/redix_sentinel.ex
+++ b/lib/redix_sentinel.ex
@@ -279,7 +279,7 @@ defmodule RedixSentinel do
     role = Keyword.fetch!(s.sentinel_opts, :role)
     current = self()
     {pid, reference} = spawn_monitor(fn ->
-      [^role | _] = Redix.command!(node, ["ROLE"])
+      confirm_role!(node, role)
       send(current, {:ok})
     end)
     receive do


### PR DESCRIPTION
Hello there 👋 ,

I'm using your library on a project and I ran into an issue: 

After the lib asks the sentinels who the master is (in `try_sentinel`) it verifies their response by calling `ROLE` on the returned master. Unfortunately (for me) the ROLE command was introduced in Redis v2.8.12, but I need to connect to v2.8.8.

I noticed that there is already a `verify_role` option that is being used by the `schedule_verification` function, so I brought the same logic into the `try_sentinel` function, which solved my problem. 🎉 

I don't have a lot of context on the verification process that you've laid out, but if you think this would be a useful addition, please bring it into master (personally, I'd rather get my libs from the source instead of maintaining my own fork 😄 ).