### PR TITLE
use redix version 0.6.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule RedixSentinel.Mixfile do
 
   defp deps do
     [
-      {:redix, "~> 0.6"},
+      {:redix, "~> 0.6.1"},
       {:connection, "~> 1.0.3"},
 
       {:ex_doc, "~> 0.16", only: :dev},


### PR DESCRIPTION
`redix` introduces breaking changes in minor releases. Version 0.7.0 [dropped support for Elixir <1.3](https://github.com/whatyouhide/redix/blob/master/CHANGELOG.md#v070) (`redix_sentinel` requires 1.2 and higher, thus is incompatible with this change) and versions 0.8.x result in [ some quite important deprecation warnings](https://github.com/whatyouhide/redix/blob/master/CHANGELOG.md#v080).

Stricter versions range for `redix` is a quick and easy fix. I've tried to upgrade it to 0.8.2, but I couldn't get the tests to pass with it (I didn't have much time to figure out why). Not to mention we've encountered an issue with Redis connections not closing properly in this version (I'll report this), 0.6.1 works fine.

Let me know what you think!